### PR TITLE
Add signed token flow for runner submissions

### DIFF
--- a/supabase/functions/game-start/index.ts
+++ b/supabase/functions/game-start/index.ts
@@ -1,0 +1,104 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Client-Info, Apikey",
+};
+
+const encoder = new TextEncoder();
+
+async function importSignatureKey(secret: string) {
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+type GameType = "runner" | "memory";
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 200,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      {
+        global: {
+          headers: { Authorization: req.headers.get("Authorization") ?? "" },
+        },
+      },
+    );
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return new Response(
+        JSON.stringify({ error: "Unauthorized" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const body = req.method === "POST" ? await req.json() : {};
+    const game: GameType = body.game ?? "runner";
+
+    if (game !== "runner" && game !== "memory") {
+      return new Response(
+        JSON.stringify({ error: "Unsupported game" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const secret = Deno.env.get("GAME_SIGNATURE_SECRET");
+    if (!secret) {
+      throw new Error("Missing GAME_SIGNATURE_SECRET environment variable");
+    }
+
+    const key = await importSignatureKey(secret);
+    const seed = crypto.randomUUID();
+    const message = `${game}|${seed}|${user.id}`;
+    const signatureBuffer = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+    const signature = arrayBufferToBase64(signatureBuffer);
+
+    return new Response(
+      JSON.stringify({ seed, signature, game }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Game start error:", error);
+    return new Response(
+      JSON.stringify({ error: error.message ?? "Unknown error" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `game-start` edge function that signs game seeds with the server secret
- update the runner client to request a signed seed before play and include the signature when submitting
- verify signatures in the `game-submit` function and reject tampered submissions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f771a09d883218f12bf9eb051504c)