### PR TITLE
Handle missing QR HMAC secret and document secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install
 
 ### 2. Konfiguracja Supabase
 
-Zmienne środowiskowe są już skonfigurowane w pliku `.env`:
+Zmienne środowiskowe aplikacji są już skonfigurowane w pliku `.env`:
 
 ```env
 EXPO_PUBLIC_SUPABASE_URL=https://dbayfxzkmaunafrrkpgw.supabase.co
@@ -37,6 +37,14 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=twój_anon_key
 ```
 
 ### 3. Zastosuj migracje (już wykonane)
+
+Edge Functions wymagają dodatkowo tajnego klucza HMAC do podpisywania jednorazowych ofert QR. Klucz nie powinien być przechowywany w repozytorium – ustaw go jako sekret środowiskowy w Supabase i rotuj poza kodem, np. za pomocą Supabase CLI:
+
+```bash
+supabase secrets set QR_HMAC_SECRET="super-bezpieczny-klucz"
+```
+
+Po aktualizacji klucza uruchom ponownie funkcję (deploy) aby wczytała nową wartość.
 
 Baza danych została już skonfigurowana z następującymi tabelami:
 - `users_extended` - rozszerzenie auth.users

--- a/supabase/functions/qr-create/index.ts
+++ b/supabase/functions/qr-create/index.ts
@@ -82,7 +82,17 @@ Deno.serve(async (req: Request) => {
     const timestamp = new Date().toISOString();
     const expiresAt = new Date(Date.now() + 120000).toISOString();
 
-    const secret = Deno.env.get("QR_HMAC_SECRET") ?? "default-secret-change-in-production";
+    const secret = Deno.env.get("QR_HMAC_SECRET");
+    if (!secret) {
+      console.error("QR create misconfiguration: QR_HMAC_SECRET is not set");
+      return new Response(
+        JSON.stringify({ error: "Server misconfiguration" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
     const payload = `${offerId}|${user.id}|${cardInstanceId}|${timestamp}`;
     const hmac = await generateHMAC(payload, secret);
 


### PR DESCRIPTION
## Summary
- return a 500 error when the QR HMAC secret is missing instead of falling back to a default value
- document how to manage the QR_HMAC_SECRET using Supabase environment secrets outside of the repository

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7642a96c8321810f404fc5e01f05)